### PR TITLE
Add option `basedir` for easily specify base directory for URL rebasing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gulp.task('default', function () {
 });
 ```
 
-**TIP: for a proper import inlining and url rebase, make sure you set the proper `base` for the input files.**
+**TIP: for a proper import inlining and url rebase, make sure you set the proper `base` for the input files or by using `basedir` option.**
 
 ## API
 
@@ -36,6 +36,7 @@ gulp.task('default', function () {
 * `options`: (since 2.1.0)
     * `inlineImports`: (default `true`) Inline any local import statement found
     * `rebaseUrls`: (default `true`) Adjust any relative URL to the location of the target file.
+    * `basedir`: (default `null`) Absolute path to base directory used for URL rebasing.
     * `includePaths`: (default `[]`) Include additional paths when inlining imports
 
 ## License

--- a/index.js
+++ b/index.js
@@ -10,13 +10,14 @@ var defaults = require('lodash.defaults');
 
 module.exports = function(destFile, options) {
   var buffer = [];
-  var firstFile, commonBase;
+  var firstFile;
   var destDir = path.dirname(destFile);
   var urlImportRules = [];
   options = defaults({}, options, {
     inlineImports: true,
     rebaseUrls: true,
-    includePaths: []
+    includePaths: [],
+    basedir: null
   });
 
   return through.obj(function(file, enc, cb) {
@@ -29,7 +30,6 @@ module.exports = function(destFile, options) {
 
     if(!firstFile) {
       firstFile = file;
-      commonBase = file.base;
     }
 
     function urlPlugin(file) {
@@ -38,7 +38,8 @@ module.exports = function(destFile, options) {
           return url;
         }
 
-        var resourceAbsUrl = path.relative(commonBase, path.resolve(path.dirname(file), url));
+        var basedir = options.basedir || firstFile.base;
+        var resourceAbsUrl = path.relative(basedir, path.resolve(path.dirname(file), url));
         resourceAbsUrl = path.relative(destDir, resourceAbsUrl);
         //not all systems use forward slash as path separator
         //this is required by urls.

--- a/test/expected/build/bundle-rebase-option-base.css
+++ b/test/expected/build/bundle-rebase-option-base.css
@@ -1,0 +1,15 @@
+@import url('subdir/imported.css');
+@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic");
+@font-face {
+  font-family: 'Font';
+  src: url("../fixtures/lib/fonts/webfont.eot?v=4.0.0");
+  src: url("../fixtures/lib/fonts/webfont.eot");
+}
+@font-face {
+  font-family: 'Font1';
+  src: url("../fixtures/lib/fonts/webfont.eot");
+}
+
+.navbar-header {
+  clear: both;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,26 @@ describe('gulp-concat-css', function() {
     stream.end();
   });
 
+  it('should only rebase urls with `base` option', function(done) {
+    var now = Date.now();
+    var stream = concatCss('build/bundle-rebase-option-base.css', {inlineImports: false, basedir: __dirname});
+    var expectedFile = expected('build/bundle-rebase-option-base.css');
+    stream
+      .pipe(through.obj(function(file, enc, cb) {
+        //fs.writeFileSync("bundle.css", file.contents);
+
+        expect(String(file.contents)).to.be.equal(String(expectedFile.contents));
+        expect(path.basename(file.path)).to.be.equal(path.basename(expectedFile.path));
+        expect(file.cwd, "cwd").to.be.equal(expectedFile.cwd);
+        expect(file.relative, "relative").to.be.equal(expectedFile.relative);
+        console.log('Execution time: ' + (Date.now() - now) + 'ms');
+        done();
+      }));
+
+    stream.write(fixture('main.css'));
+    stream.write(fixture('vendor/vendor.css'));
+    stream.end();
+  });
 
   it('should only inline imports', function(done) {
     var now = Date.now();


### PR DESCRIPTION
Manually overwriting the root directory used for URL rebasing is a common task and for now, there was no easy way to do that. Now we have the `basedir` option.