### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var Vinyl = require('vinyl');
 var path = require('path');
 var rework = require('rework');
 var reworkImport = require('rework-import');
@@ -23,7 +24,7 @@ module.exports = function(destFile, options) {
     var processedCss;
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-concat-css', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-concat-css', 'Streaming not supported'));
       return cb();
     }
 
@@ -99,7 +100,7 @@ module.exports = function(destFile, options) {
 
       processedCss = processedCss.toString();
     } catch(err) {
-      this.emit('error', new gutil.PluginError('gulp-concat-css', err));
+      this.emit('error', new PluginError('gulp-concat-css', err));
       return cb();
     }
 
@@ -112,9 +113,9 @@ module.exports = function(destFile, options) {
 
     var contents = urlImportRules.map(function(rule) {
       return '@import ' + rule.import + ';';
-    }).concat(buffer).join(gutil.linefeed);
+    }).concat(buffer).join('\n');
 
-    var concatenatedFile = new gutil.File({
+    var concatenatedFile = new Vinyl({
       base: firstFile.base,
       cwd: firstFile.cwd,
       path: path.join(firstFile.base, destFile),

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     }
   ],
   "dependencies": {
-    "gulp-util": "~3.0.1",
     "lodash.defaults": "^3.0.0",
     "parse-import": "^2.0.0",
+    "plugin-error": "^0.1.2",
     "rework": "~1.0.0",
     "rework-import": "^2.0.0",
     "rework-plugin-url": "^1.0.1",
-    "through2": "~1.1.1"
+    "through2": "~1.1.1",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect,
   through = require('through2'),
-  gutil = require('gulp-util'),
+  Vinyl = require('vinyl'),
   fs = require('fs'),
   path = require('path'),
   concatCss = require('../');
@@ -9,7 +9,7 @@ var expect = require('chai').expect,
 function expected(file) {
   var base = path.join(process.cwd(), 'test/expected');
   var filepath = path.resolve(base, file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: process.cwd(),
     base: base,
@@ -20,7 +20,7 @@ function expected(file) {
 function fixture(file) {
   var base = path.join(process.cwd(), 'test/fixtures');
   var filepath = path.join(base, file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: process.cwd(),
     base: base,


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so **it is important to replace `gulp-util`**.

Your package is one of the most popular packages still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143